### PR TITLE
Client: Add OpenAG features

### DIFF
--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -687,7 +687,7 @@ void CHud::UpdateSupportsCvar()
 	gEngfuncs.pfnClientCmd(buf);
 }
 
-CON_COMMAND(append, "Support OpenAG scripts.")
+CON_COMMAND(append, "Puts a command into the end of the command buffer")
 {
 	if (gEngfuncs.Cmd_Argc() != 2) {
 		if (!gEngfuncs.pDemoAPI->IsPlayingback())

--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -689,7 +689,8 @@ void CHud::UpdateSupportsCvar()
 
 CON_COMMAND(append, "Puts a command into the end of the command buffer")
 {
-	if (gEngfuncs.Cmd_Argc() != 2) {
+	if (gEngfuncs.Cmd_Argc() != 2)
+	{
 		if (!gEngfuncs.pDemoAPI->IsPlayingback())
 			gEngfuncs.Con_Printf("append <command> - put the command into the end of the command buffer.\n");
 

--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -206,6 +206,8 @@ void CHud::Init(void)
 
 	HookCommand("about", AboutCommand);
 
+	EngineClientCmd("alias zpecial \"append _zpecial\"");
+
 	HookViewportMessage<&CClientViewport::MsgFunc_ValClass>("ValClass");
 	HookViewportMessage<&CClientViewport::MsgFunc_TeamNames>("TeamNames");
 	HookViewportMessage<&CClientViewport::MsgFunc_Feign>("Feign");
@@ -683,6 +685,18 @@ void CHud::UpdateSupportsCvar()
 	char buf[64];
 	snprintf(buf, sizeof(buf), "aghl_supports %u", static_cast<unsigned int>(supports));
 	gEngfuncs.pfnClientCmd(buf);
+}
+
+CON_COMMAND(append, "Support OpenAG scripts.")
+{
+	if (gEngfuncs.Cmd_Argc() != 2) {
+		if (!gEngfuncs.pDemoAPI->IsPlayingback())
+			gEngfuncs.Con_Printf("append <command> - put the command into the end of the command buffer.\n");
+
+		return;
+	}
+
+	EngineClientCmd(gEngfuncs.Cmd_Argv(1));
 }
 
 CON_COMMAND(_toggle, "Switches cvar values from arguments.")

--- a/src/game/client/hud/crosshair.cpp
+++ b/src/game/client/hud/crosshair.cpp
@@ -30,13 +30,10 @@ void CHudCrosshair::Draw(float flTime)
 	if (!(gHUD.m_iWeaponBits & (1 << (WEAPON_SUIT))))
 		return;
 
-	if ((gHUD.m_iHideHUDDisplay & (HIDEHUD_WEAPONS | HIDEHUD_ALL)))
+	if (gHUD.m_iHideHUDDisplay & HIDEHUD_ALL)
 		return;
 
 	if (!(m_iFlags & HUD_ACTIVE))
-		return;
-
-	if (!CHudAmmo::Get()->m_pWeapon)
 		return;
 
 	// Draw custom crosshair if enabled

--- a/src/game/client/hud/crosshair.cpp
+++ b/src/game/client/hud/crosshair.cpp
@@ -36,8 +36,14 @@ void CHudCrosshair::Draw(float flTime)
 	if (!(m_iFlags & HUD_ACTIVE))
 		return;
 
-	if (!CHudAmmo::Get()->m_pWeapon)
-		return;
+	if (gEngfuncs.GetMaxClients() == 1)
+	{
+		// These checks are limited to singleplayer since HL servers
+		// reset the HUD incorrectly on full update (e.g. when starting a demo recording).
+		// This causes ammo count and crosshair to disappear.
+		if ((gHUD.m_iHideHUDDisplay & HIDEHUD_WEAPONS) || !CHudAmmo::Get()->m_pWeapon)
+			return;
+	}
 
 	// Draw custom crosshair if enabled
 	if (cl_cross_enable.GetBool() && !(CHudAmmo::Get()->m_fOnTarget && CHudAmmo::Get()->m_pWeapon->hAutoaim))

--- a/src/game/client/hud/crosshair.cpp
+++ b/src/game/client/hud/crosshair.cpp
@@ -36,6 +36,9 @@ void CHudCrosshair::Draw(float flTime)
 	if (!(m_iFlags & HUD_ACTIVE))
 		return;
 
+	if (!CHudAmmo::Get()->m_pWeapon)
+		return;
+
 	// Draw custom crosshair if enabled
 	if (cl_cross_enable.GetBool() && !(CHudAmmo::Get()->m_fOnTarget && CHudAmmo::Get()->m_pWeapon->hAutoaim))
 	{

--- a/src/game/client/hud/speedometer.cpp
+++ b/src/game/client/hud/speedometer.cpp
@@ -11,6 +11,7 @@ DEFINE_HUD_ELEM(CHudSpeedometer);
 void CHudSpeedometer::Init()
 {
 	m_iFlags = HUD_ACTIVE;
+	m_pCvarSpeedometerBelowCross = CVAR_CREATE("hud_speedometer_below_cross", "0", FCVAR_BHL_ARCHIVE);
 }
 
 void CHudSpeedometer::VidInit()
@@ -44,10 +45,16 @@ void CHudSpeedometer::Draw(float time)
 	else
 		a = MIN_ALPHA;
 
+	int y;
+	if (m_pCvarSpeedometerBelowCross->value != 0)
+		y = ScreenHeight / 2 + gHUD.m_iFontHeight / 2;
+	else
+		y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2;
+
 	a *= gHUD.GetHudTransparency();
 	gHUD.GetHudColor(HudPart::Common, 0, r, g, b);
 	ScaleColors(r, g, b, a);
-	gHUD.DrawHudNumberCentered(ScreenWidth / 2, ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2, m_iSpeed, r, g, b);
+	gHUD.DrawHudNumberCentered(ScreenWidth / 2, y, m_iSpeed, r, g, b);
 
 	m_iOldSpeed = m_iSpeed;
 }

--- a/src/game/client/hud/speedometer.cpp
+++ b/src/game/client/hud/speedometer.cpp
@@ -4,14 +4,14 @@
 #include "parsemsg.h"
 #include "speedometer.h"
 
-static ConVar hud_speedometer("hud_speedometer", "0", FCVAR_BHL_ARCHIVE);
+static ConVar hud_speedometer("hud_speedometer", "0", FCVAR_BHL_ARCHIVE, "Enable speedometer");
+static ConVar hud_speedometer_below_cross("hud_speedometer_below_cross", "0", FCVAR_BHL_ARCHIVE, "Move speedometer to below the crosshair");
 
 DEFINE_HUD_ELEM(CHudSpeedometer);
 
 void CHudSpeedometer::Init()
 {
 	m_iFlags = HUD_ACTIVE;
-	m_pCvarSpeedometerBelowCross = CVAR_CREATE("hud_speedometer_below_cross", "0", FCVAR_BHL_ARCHIVE);
 }
 
 void CHudSpeedometer::VidInit()
@@ -46,7 +46,7 @@ void CHudSpeedometer::Draw(float time)
 		a = MIN_ALPHA;
 
 	int y;
-	if (m_pCvarSpeedometerBelowCross->value != 0)
+	if (hud_speedometer_below_cross.GetBool())
 		y = ScreenHeight / 2 + gHUD.m_iFontHeight / 2;
 	else
 		y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2;

--- a/src/game/client/hud/speedometer.h
+++ b/src/game/client/hud/speedometer.h
@@ -14,7 +14,6 @@ private:
 	int m_iOldSpeed;
 	int m_iSpeed;
 	float m_fFade;
-	cvar_t *m_pCvarSpeedometerBelowCross;
 };
 
 #endif

--- a/src/game/client/hud/speedometer.h
+++ b/src/game/client/hud/speedometer.h
@@ -14,7 +14,7 @@ private:
 	int m_iOldSpeed;
 	int m_iSpeed;
 	float m_fFade;
-	cvar_t *m_pCvarSpeedometer;
+	cvar_t *m_pCvarSpeedometerBelowCross;
 };
 
 #endif

--- a/src/game/client/input.cpp
+++ b/src/game/client/input.cpp
@@ -68,6 +68,68 @@ cvar_t *cl_pitchspeed;
 cvar_t *cl_anglespeedkey;
 cvar_t *cl_vsmoothing;
 cvar_t *cl_jumptype;
+cvar_t *cl_autojump_priority;
+
+namespace autofuncs
+{
+	static cvar_t* cl_autojump;
+
+	static struct {
+		bool onground = false;
+		bool inwater = false;
+		bool walking = true; // Movetype == MOVETYPE_WALK. Filters out noclip, being on ladder, etc.
+	} player;
+
+	static void handle_autojump(usercmd_t* cmd)
+	{
+		static bool s_jump_was_down_last_frame = false;
+
+		if (cl_autojump->value != 0.0f)
+		{
+			bool should_release_jump = (!player.onground && !player.inwater && player.walking);
+
+			/*
+			 * Spam pressing and releasing jump if we're stuck in a spot where jumping still results in
+			 * being onground in the end of the frame. Without this check, +jump would remain held and
+			 * when the player exits this spot they would have to release and press the jump button to
+			 * start jumping again. This also helps with exiting water or ladder right onto the ground.
+			 */
+			if (s_jump_was_down_last_frame && player.onground && !player.inwater && player.walking)
+				should_release_jump = true;
+
+			if (should_release_jump)
+				cmd->buttons &= ~IN_JUMP;
+		}
+
+		s_jump_was_down_last_frame = ((cmd->buttons & IN_JUMP) != 0);
+	}
+
+	static void handle_ducktap(usercmd_t* cmd)
+	{
+		static bool s_duck_was_down_last_frame = false;
+
+		bool should_release_duck = (!player.onground && !player.inwater && player.walking);
+
+		if (s_duck_was_down_last_frame && player.onground && !player.inwater && player.walking)
+		{
+			should_release_duck = true;
+		}
+
+		if (should_release_duck)
+		{
+			cmd->buttons &= ~IN_DUCK;
+		}
+
+		s_duck_was_down_last_frame = ((cmd->buttons & IN_DUCK) != 0);
+	}
+}
+
+extern "C" void update_player_info(int onground, int inwater, int walking)
+{
+	autofuncs::player.onground = (onground != 0);
+	autofuncs::player.inwater = (inwater != 0);
+	autofuncs::player.walking = (walking != 0);
+}
 
 /*
 ===============================================================================
@@ -117,6 +179,7 @@ kbutton_t in_alt1;
 kbutton_t in_score;
 kbutton_t in_break;
 kbutton_t in_graph; // Display the netgraph
+kbutton_t in_ducktap;
 
 typedef struct kblist_s
 {
@@ -396,6 +459,8 @@ void IN_LeftDown(void) { KeyDown(&in_left); }
 void IN_LeftUp(void) { KeyUp(&in_left); }
 void IN_RightDown(void) { KeyDown(&in_right); }
 void IN_RightUp(void) { KeyUp(&in_right); }
+void IN_DucktapUp(void) { KeyUp(&in_ducktap); }
+void IN_DucktapDown(void) { KeyDown(&in_ducktap); }
 
 void IN_ForwardDown(void)
 {
@@ -742,6 +807,16 @@ void CL_DLLEXPORT CL_CreateMove(float frametime, struct usercmd_s *cmd, int acti
 	//
 	cmd->buttons = CL_ButtonBits(1);
 
+	if (cl_autojump_priority->value != 0.0f)
+		autofuncs::handle_autojump(cmd);
+
+	if (in_ducktap.state & 1)
+	{
+		cmd->buttons |= IN_DUCK;
+		autofuncs::handle_ducktap(cmd); // Ducktap takes priority over autojump
+	} else if (cl_autojump_priority->value == 0.0f)
+		autofuncs::handle_autojump(cmd);
+
 	// Using joystick?
 	if (in_joystick->value)
 	{
@@ -805,7 +880,7 @@ int CL_ButtonBits(int bResetState)
 
 	if (in_jump.state & 3)
 	{
-		if (cl_jumptype->value == 0.0 || g_iUser1) // Simple jump in spectator
+		if (cl_jumptype->value == 0.0 || g_iUser1 || autofuncs::cl_autojump->value != 0.0f) // Simple jump in spectator
 		{
 			bits |= IN_JUMP;
 		}
@@ -981,6 +1056,7 @@ int CL_ButtonBits(int bResetState)
 		in_reload.state &= ~2;
 		in_alt1.state &= ~2;
 		in_score.state &= ~2;
+		in_ducktap.state &= ~2;
 	}
 
 	return bits;
@@ -1076,6 +1152,8 @@ void InitInput(void)
 	gEngfuncs.pfnAddCommand("-graph", IN_GraphUp);
 	gEngfuncs.pfnAddCommand("+break", IN_BreakDown);
 	gEngfuncs.pfnAddCommand("-break", IN_BreakUp);
+	gEngfuncs.pfnAddCommand("+ducktap", IN_DucktapDown);
+	gEngfuncs.pfnAddCommand("-ducktap", IN_DucktapUp);
 
 	lookstrafe = gEngfuncs.pfnRegisterVariable("lookstrafe", "0", FCVAR_ARCHIVE);
 	lookspring = gEngfuncs.pfnRegisterVariable("lookspring", "0", FCVAR_ARCHIVE);
@@ -1092,6 +1170,9 @@ void InitInput(void)
 
 	cl_vsmoothing = gEngfuncs.pfnRegisterVariable("cl_vsmoothing", "0.05", FCVAR_ARCHIVE);
 	cl_jumptype = gEngfuncs.pfnRegisterVariable("cl_jumptype", "1", FCVAR_ARCHIVE);
+	
+	autofuncs::cl_autojump = gEngfuncs.pfnRegisterVariable ( "cl_autojump", "0", FCVAR_ARCHIVE );
+	cl_autojump_priority = gEngfuncs.pfnRegisterVariable ( "cl_autojump_priority", "0", FCVAR_ARCHIVE );
 
 	m_pitch = gEngfuncs.pfnRegisterVariable("m_pitch", "0.022", FCVAR_ARCHIVE);
 	m_yaw = gEngfuncs.pfnRegisterVariable("m_yaw", "0.022", FCVAR_ARCHIVE);

--- a/src/game/client/input.cpp
+++ b/src/game/client/input.cpp
@@ -74,54 +74,54 @@ ConVar cl_autojump_priority("cl_autojump_priority", "0", FCVAR_BHL_ARCHIVE, "Aut
 
 namespace autofuncs
 {
-	static void HandleAutojump(usercmd_t *cmd)
+static void HandleAutojump(usercmd_t *cmd)
+{
+	static bool s_bJumpWasDownLastFrame = false;
+
+	bool inWater = PM_GetWaterLevel() > 1;
+	bool isWalking = PM_GetMoveType() == MOVETYPE_WALK;
+	bool shouldReleaseDuck = (!PM_GetOnGround() && !inWater && isWalking);
+
+	if (cl_autojump.GetBool())
 	{
-		static bool s_bJumpWasDownLastFrame = false;
+		bool shouldReleaseJump = (!PM_GetOnGround() && !inWater && isWalking);
 
-		bool inWater = PM_GetWaterLevel() > 1;
-	    bool isWalking = PM_GetMoveType() == MOVETYPE_WALK;
-	    bool shouldReleaseDuck = (!PM_GetOnGround() && !inWater && isWalking);
-
-		if (cl_autojump.GetBool())
-		{
-		    bool shouldReleaseJump = (!PM_GetOnGround() && !inWater && isWalking);
-
-			/*
+		/*
 			 * Spam pressing and releasing jump if we're stuck in a spot where jumping still results in
 			 * being onground in the end of the frame. Without this check, +jump would remain held and
 			 * when the player exits this spot they would have to release and press the jump button to
 			 * start jumping again. This also helps with exiting water or ladder right onto the ground.
 			 */
-		    if (s_bJumpWasDownLastFrame && PM_GetOnGround() && !inWater && isWalking)
-			    shouldReleaseJump = true;
+		if (s_bJumpWasDownLastFrame && PM_GetOnGround() && !inWater && isWalking)
+			shouldReleaseJump = true;
 
-			if (shouldReleaseJump)
-				cmd->buttons &= ~IN_JUMP;
-		}
-
-		s_bJumpWasDownLastFrame = ((cmd->buttons & IN_JUMP) != 0);
+		if (shouldReleaseJump)
+			cmd->buttons &= ~IN_JUMP;
 	}
 
-	static void HandleDucktap(usercmd_t* cmd)
+	s_bJumpWasDownLastFrame = ((cmd->buttons & IN_JUMP) != 0);
+}
+
+static void HandleDucktap(usercmd_t *cmd)
+{
+	static bool s_bDuckWasDownLastFrame = false;
+
+	bool inWater = PM_GetWaterLevel() > 1;
+	bool isWalking = PM_GetMoveType() == MOVETYPE_WALK;
+	bool shouldReleaseDuck = (!PM_GetOnGround() && !inWater && isWalking);
+
+	if (s_bDuckWasDownLastFrame && PM_GetOnGround() && !inWater && isWalking)
 	{
-		static bool s_bDuckWasDownLastFrame = false;
-
-		bool inWater = PM_GetWaterLevel() > 1;
-	    bool isWalking = PM_GetMoveType() == MOVETYPE_WALK;
-	    bool shouldReleaseDuck = (!PM_GetOnGround() && !inWater && isWalking);
-
-		if (s_bDuckWasDownLastFrame && PM_GetOnGround() && !inWater && isWalking)
-		{
-		    shouldReleaseDuck = true;
-		}
-
-		if (shouldReleaseDuck)
-		{
-			cmd->buttons &= ~IN_DUCK;
-		}
-
-		s_bDuckWasDownLastFrame = ((cmd->buttons & IN_DUCK) != 0);
+		shouldReleaseDuck = true;
 	}
+
+	if (shouldReleaseDuck)
+	{
+		cmd->buttons &= ~IN_DUCK;
+	}
+
+	s_bDuckWasDownLastFrame = ((cmd->buttons & IN_DUCK) != 0);
+}
 }
 
 /*

--- a/src/game/client/input.cpp
+++ b/src/game/client/input.cpp
@@ -68,25 +68,23 @@ cvar_t *cl_pitchspeed;
 cvar_t *cl_anglespeedkey;
 cvar_t *cl_vsmoothing;
 cvar_t *cl_jumptype;
-cvar_t *cl_autojump_priority;
+
+ConVar cl_autojump("cl_autojump", "0", FCVAR_BHL_ARCHIVE, "Jump automatically when ground is hit");
+ConVar cl_autojump_priority("cl_autojump_priority", "0", FCVAR_BHL_ARCHIVE, "Autojump takes priority over ducktap");
 
 namespace autofuncs
 {
-	static cvar_t* cl_autojump;
-
-	static struct {
-		bool onground = false;
-		bool inwater = false;
-		bool walking = true; // Movetype == MOVETYPE_WALK. Filters out noclip, being on ladder, etc.
-	} player;
-
-	static void handle_autojump(usercmd_t* cmd)
+	static void HandleAutojump(usercmd_t *cmd)
 	{
-		static bool s_jump_was_down_last_frame = false;
+		static bool s_bJumpWasDownLastFrame = false;
 
-		if (cl_autojump->value != 0.0f)
+		bool inWater = PM_GetWaterLevel() > 1;
+	    bool isWalking = PM_GetMoveType() == MOVETYPE_WALK;
+	    bool shouldReleaseDuck = (!PM_GetOnGround() && !inWater && isWalking);
+
+		if (cl_autojump.GetBool())
 		{
-			bool should_release_jump = (!player.onground && !player.inwater && player.walking);
+		    bool shouldReleaseJump = (!PM_GetOnGround() && !inWater && isWalking);
 
 			/*
 			 * Spam pressing and releasing jump if we're stuck in a spot where jumping still results in
@@ -94,41 +92,36 @@ namespace autofuncs
 			 * when the player exits this spot they would have to release and press the jump button to
 			 * start jumping again. This also helps with exiting water or ladder right onto the ground.
 			 */
-			if (s_jump_was_down_last_frame && player.onground && !player.inwater && player.walking)
-				should_release_jump = true;
+		    if (s_bJumpWasDownLastFrame && PM_GetOnGround() && !inWater && isWalking)
+			    shouldReleaseJump = true;
 
-			if (should_release_jump)
+			if (shouldReleaseJump)
 				cmd->buttons &= ~IN_JUMP;
 		}
 
-		s_jump_was_down_last_frame = ((cmd->buttons & IN_JUMP) != 0);
+		s_bJumpWasDownLastFrame = ((cmd->buttons & IN_JUMP) != 0);
 	}
 
-	static void handle_ducktap(usercmd_t* cmd)
+	static void HandleDucktap(usercmd_t* cmd)
 	{
-		static bool s_duck_was_down_last_frame = false;
+		static bool s_bDuckWasDownLastFrame = false;
 
-		bool should_release_duck = (!player.onground && !player.inwater && player.walking);
+		bool inWater = PM_GetWaterLevel() > 1;
+	    bool isWalking = PM_GetMoveType() == MOVETYPE_WALK;
+	    bool shouldReleaseDuck = (!PM_GetOnGround() && !inWater && isWalking);
 
-		if (s_duck_was_down_last_frame && player.onground && !player.inwater && player.walking)
+		if (s_bDuckWasDownLastFrame && PM_GetOnGround() && !inWater && isWalking)
 		{
-			should_release_duck = true;
+		    shouldReleaseDuck = true;
 		}
 
-		if (should_release_duck)
+		if (shouldReleaseDuck)
 		{
 			cmd->buttons &= ~IN_DUCK;
 		}
 
-		s_duck_was_down_last_frame = ((cmd->buttons & IN_DUCK) != 0);
+		s_bDuckWasDownLastFrame = ((cmd->buttons & IN_DUCK) != 0);
 	}
-}
-
-extern "C" void update_player_info(int onground, int inwater, int walking)
-{
-	autofuncs::player.onground = (onground != 0);
-	autofuncs::player.inwater = (inwater != 0);
-	autofuncs::player.walking = (walking != 0);
 }
 
 /*
@@ -168,7 +161,6 @@ kbutton_t in_speed;
 kbutton_t in_use;
 kbutton_t in_jump;
 kbutton_t in_longjump;
-kbutton_t in_bunnyhop;
 kbutton_t in_attack;
 kbutton_t in_attack2;
 kbutton_t in_up;
@@ -546,8 +538,6 @@ void IN_JumpDown(void)
 void IN_JumpUp(void) { KeyUp(&in_jump); }
 void IN_LongJumpDown(void) { KeyDown(&in_longjump); }
 void IN_LongJumpUp(void) { KeyUp(&in_longjump); }
-void IN_BunnyHopDown(void) { KeyDown(&in_bunnyhop); }
-void IN_BunnyHopUp(void) { KeyUp(&in_bunnyhop); }
 void IN_DuckDown(void)
 {
 	KeyDown(&in_duck);
@@ -760,7 +750,7 @@ void CL_DLLEXPORT CL_CreateMove(float frametime, struct usercmd_s *cmd, int acti
 		cmd->sidemove -= cl_sidespeed->value * CL_KeyState(&in_moveleft);
 
 		// simulate moveup underwater for +bhop, +ljump and +jump actions
-		cmd->upmove += cl_upspeed->value * std::max(CL_KeyState(&in_up), PM_GetWaterLevel() >= 2 ? max(max(CL_KeyState(&in_bunnyhop), CL_KeyState(&in_jump)), CL_KeyState(&in_longjump)) : 0);
+		cmd->upmove += cl_upspeed->value * std::max(CL_KeyState(&in_up), PM_GetWaterLevel() >= 2 ? max(CL_KeyState(&in_jump), CL_KeyState(&in_longjump)) : 0);
 		cmd->upmove -= cl_upspeed->value * CL_KeyState(&in_down);
 
 		if (!(in_klook.state & 1))
@@ -807,15 +797,18 @@ void CL_DLLEXPORT CL_CreateMove(float frametime, struct usercmd_s *cmd, int acti
 	//
 	cmd->buttons = CL_ButtonBits(1);
 
-	if (cl_autojump_priority->value != 0.0f)
-		autofuncs::handle_autojump(cmd);
+	if (cl_autojump_priority.GetBool())
+		autofuncs::HandleAutojump(cmd);
 
 	if (in_ducktap.state & 1)
 	{
 		cmd->buttons |= IN_DUCK;
-		autofuncs::handle_ducktap(cmd); // Ducktap takes priority over autojump
-	} else if (cl_autojump_priority->value == 0.0f)
-		autofuncs::handle_autojump(cmd);
+		autofuncs::HandleDucktap(cmd); // Ducktap takes priority over autojump
+	}
+	else if (!cl_autojump_priority.GetBool())
+	{
+		autofuncs::HandleAutojump(cmd);
+	}
 
 	// Using joystick?
 	if (in_joystick->value)
@@ -880,7 +873,7 @@ int CL_ButtonBits(int bResetState)
 
 	if (in_jump.state & 3)
 	{
-		if (cl_jumptype->value == 0.0 || g_iUser1 || autofuncs::cl_autojump->value != 0.0f) // Simple jump in spectator
+		if (cl_jumptype->value == 0.0 || g_iUser1 || cl_autojump.GetBool()) // Simple jump in spectator
 		{
 			bits |= IN_JUMP;
 		}
@@ -940,35 +933,6 @@ int CL_ButtonBits(int bResetState)
 		if (bResetState)
 		{
 			g_bLongJumped = false;
-		}
-	}
-
-	if (in_bunnyhop.state & 3)
-	{
-		if (g_iUser1) // Simple jump in spectator
-		{
-			bits |= IN_JUMP;
-		}
-		else if (PM_GetOnGround())
-		{
-			if (!g_bBunnyhopJumped)
-			{
-				bits |= IN_JUMP;
-			}
-			if (bResetState)
-			{
-				g_bBunnyhopJumped = !g_bBunnyhopJumped;
-			}
-		}
-		else
-		{
-			g_bBunnyhopJumped = false;
-
-			if (PM_GetWaterLevel() == 2)
-			{
-				// Over the water, glide on the surface, but only if we are over deep water
-				bits |= IN_JUMP;
-			}
 		}
 	}
 
@@ -1044,7 +1008,6 @@ int CL_ButtonBits(int bResetState)
 		in_duck.state &= ~2;
 		in_jump.state &= ~2;
 		in_longjump.state &= ~2;
-		in_bunnyhop.state &= ~2;
 		in_forward.state &= ~2;
 		in_back.state &= ~2;
 		in_use.state &= ~2;
@@ -1129,8 +1092,6 @@ void InitInput(void)
 	gEngfuncs.pfnAddCommand("-jump", IN_JumpUp);
 	gEngfuncs.pfnAddCommand("+ljump", IN_LongJumpDown);
 	gEngfuncs.pfnAddCommand("-ljump", IN_LongJumpUp);
-	gEngfuncs.pfnAddCommand("+bhop", IN_BunnyHopDown);
-	gEngfuncs.pfnAddCommand("-bhop", IN_BunnyHopUp);
 	gEngfuncs.pfnAddCommand("impulse", IN_Impulse);
 	gEngfuncs.pfnAddCommand("+klook", IN_KLookDown);
 	gEngfuncs.pfnAddCommand("-klook", IN_KLookUp);
@@ -1170,9 +1131,6 @@ void InitInput(void)
 
 	cl_vsmoothing = gEngfuncs.pfnRegisterVariable("cl_vsmoothing", "0.05", FCVAR_ARCHIVE);
 	cl_jumptype = gEngfuncs.pfnRegisterVariable("cl_jumptype", "1", FCVAR_ARCHIVE);
-	
-	autofuncs::cl_autojump = gEngfuncs.pfnRegisterVariable ( "cl_autojump", "0", FCVAR_ARCHIVE );
-	cl_autojump_priority = gEngfuncs.pfnRegisterVariable ( "cl_autojump_priority", "0", FCVAR_ARCHIVE );
 
 	m_pitch = gEngfuncs.pfnRegisterVariable("m_pitch", "0.022", FCVAR_ARCHIVE);
 	m_yaw = gEngfuncs.pfnRegisterVariable("m_yaw", "0.022", FCVAR_ARCHIVE);

--- a/src/pm_shared/pm_shared.cpp
+++ b/src/pm_shared/pm_shared.cpp
@@ -3480,7 +3480,7 @@ void PM_Move(struct playermove_s *ppmove, int server)
 	// BHop autodetection
 #ifdef CLIENT_DLL
 	s_iMoveType = pmove->movetype;
-	
+
 	if (s_iBHopState == 2 && s_flBHopCheckTime > 0)
 	{
 		float speed = sqrtf(pmove->velocity[0] * pmove->velocity[0] + pmove->velocity[1] * pmove->velocity[1]);

--- a/src/pm_shared/pm_shared.cpp
+++ b/src/pm_shared/pm_shared.cpp
@@ -3470,6 +3470,15 @@ void PM_Move(struct playermove_s *ppmove, int server)
 
 	// BHop autodetection
 #ifdef CLIENT_DLL
+
+	extern void update_player_info(int onground, int inwater, int walking);
+
+	update_player_info(
+		pmove->onground != -1,
+		pmove->waterlevel > 1,
+		pmove->movetype == MOVETYPE_WALK
+	);
+	
 	if (s_iBHopState == 2 && s_flBHopCheckTime > 0)
 	{
 		float speed = sqrtf(pmove->velocity[0] * pmove->velocity[0] + pmove->velocity[1] * pmove->velocity[1]);

--- a/src/pm_shared/pm_shared.h
+++ b/src/pm_shared/pm_shared.h
@@ -23,12 +23,12 @@ void PM_Init(struct playermove_s *ppmove);
 void PM_Move(struct playermove_s *ppmove, int server);
 char PM_FindTextureType(char *name);
 
-int PM_GetOnGround();
-int PM_GetWaterLevel();
-
 void PM_SetIsAG(int state);
 
 #ifdef CLIENT_DLL
+int PM_GetOnGround();
+int PM_GetWaterLevel();
+int PM_GetMoveType();
 int PM_GetBHopCapState();
 void PM_SetBHopCapState(int state);
 void PM_ResetBHopDetection();


### PR DESCRIPTION
Closes #6, closes #32

- zpecial, so you can copy your AG scripts to HL and have them work without touching anything
- cl_autojump 0/1, again so that you don't have to change your AG scripts
- cl_autojump_priority 0/1, to decide if +jump has priority over ducktap when both are used
- cl_autojump 1 takes priority over cl_jumptype
- +ducktap
- hud_speedometer_below_cross 0/1