### PR TITLE
Client: Use ShellExecuteA instead of CreateProcess for opening notepad.exe

### DIFF
--- a/src/game/client/engine_patches_windows.cpp
+++ b/src/game/client/engine_patches_windows.cpp
@@ -846,28 +846,7 @@ public:
 
 			fclose(file);
 
-			char buf[512];
-			snprintf(buf, sizeof(buf), "notepad %s", filename);
-
-			STARTUPINFO si;
-			PROCESS_INFORMATION pi;
-			ZeroMemory(&si, sizeof(si));
-			si.cb = sizeof(si);
-			ZeroMemory(&pi, sizeof(pi));
-
-			CreateProcess(NULL, // No module name (use command line)
-			    buf, // Command line
-			    NULL, // Process handle not inheritable
-			    NULL, // Thread handle not inheritable
-			    FALSE, // Set handle inheritance to FALSE
-			    0, // No creation flags
-			    NULL, // Use parent's environment block
-			    NULL, // Use parent's starting directory
-			    &si, // Pointer to STARTUPINFO structure
-			    &pi); // Pointer to PROCESS_INFORMATION structure
-
-			CloseHandle(pi.hProcess);
-			CloseHandle(pi.hThread);
+			ShellExecuteA(NULL, "open", "notepad.exe", filename, NULL, SW_SHOWNORMAL);
 		}
 	}
 


### PR DESCRIPTION
Due to CreateProcess, Steam counts notepad.exe as game (child process) after crashing. This commit fixes this behavior.