### PR TITLE
Fix Half-Life 25th Anniversary Edition hud display bug in high resolution

### DIFF
--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -355,8 +355,12 @@ void CHud::VidInit(void)
 
 	if (ScreenWidth < 640)
 		m_iRes = 320;
-	else
+	else if (ScreenWidth < 1280)
 		m_iRes = 640;
+	else if (ScreenWidth < 2560)
+		m_iRes = 1280;
+	else
+		m_iRes = 2560;
 
 	// Only load this once
 	if (!m_pSpriteList)

--- a/src/game/client/hud/ammo.cpp
+++ b/src/game/client/hud/ammo.cpp
@@ -81,9 +81,13 @@ void WeaponsResource::LoadWeaponSprites(WEAPON *pWeapon)
 	int i, iRes;
 
 	if (ScreenWidth < 640)
-		iRes = 320;
+		m_iRes = 320;
+	else if (ScreenWidth < 1280)
+		m_iRes = 640;
+	else if (ScreenWidth < 2560)
+		m_iRes = 1280;
 	else
-		iRes = 640;
+		m_iRes = 2560;
 
 	char sz[256];
 


### PR DESCRIPTION
Valve had broken or abandoned the 640/320 settings in hud.txt, I guess，because there's no suitable spr file for the 640/320 settings. But only the spr file in hud.txt works.