### PR TITLE
Client: Server: Implement fog

### DIFF
--- a/src/game/client/CMakeLists.txt
+++ b/src/game/client/CMakeLists.txt
@@ -30,6 +30,8 @@ add_sources(
 	events.cpp
 	eventscripts.h
 	Exports.h
+	fog.cpp
+	fog.h
 	GameStudioModelRenderer.cpp
 	GameStudioModelRenderer.h
 	global_consts.h

--- a/src/game/client/fog.cpp
+++ b/src/game/client/fog.cpp
@@ -1,0 +1,42 @@
+#include "hud.h"
+#include "fog.h"
+#include "triangleapi.h"
+
+extern int g_iWaterlevel;
+
+CFog gFog;
+
+CFog::CFog()
+{
+	ClearFog();
+}
+
+void CFog::SetFogParameters(const FogParams &params)
+{
+	m_FogParams = params;
+}
+
+FogParams CFog::GetFogParameters() const
+{
+	return m_FogParams;
+}
+
+void CFog::RenderFog()
+{
+	bool bFog;
+
+	if (g_iWaterlevel <= 2) // checking if player is not underwater
+		bFog = (m_FogParams.density > 0.0f) ? true : false;
+	else
+		bFog = false;
+
+	gEngfuncs.pTriAPI->FogParams(m_FogParams.density, m_FogParams.fogSkybox);
+	gEngfuncs.pTriAPI->Fog(m_FogParams.color, FOG_START_DISTANCE, FOG_END_DISTANCE, bFog);
+}
+
+void CFog::ClearFog()
+{
+	m_FogParams.fogSkybox = false;
+	m_FogParams.color[0] = m_FogParams.color[1] = m_FogParams.color[2] = 0.0f;
+	m_FogParams.density = 0.0f;
+}

--- a/src/game/client/fog.h
+++ b/src/game/client/fog.h
@@ -1,0 +1,28 @@
+#ifndef FOG_H
+#define FOG_H
+
+#define FOG_START_DISTANCE	1500.0f
+#define FOG_END_DISTANCE	2000.0f
+
+struct FogParams
+{
+	bool fogSkybox;
+	float color[3];
+	float density;
+};
+
+class CFog
+{
+public:
+	CFog();
+	void SetFogParameters(const FogParams &params);
+	FogParams GetFogParameters() const;
+	void RenderFog();
+	void ClearFog();
+private:
+	FogParams m_FogParams;
+};
+
+extern CFog gFog;
+
+#endif // FOG_H

--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -45,6 +45,7 @@
 #include "results.h"
 #include "svc_messages.h"
 #include "sdl_rt.h"
+#include "fog.h"
 
 #if USE_UPDATER
 #include "updater/update_checker.h"
@@ -294,6 +295,7 @@ void CHud::Init(void)
 	HookHudMessage<&CHud::MsgFunc_SetFOV>("SetFOV");
 	HookHudMessage<&CHud::MsgFunc_Concuss>("Concuss");
 	HookHudMessage<&CHud::MsgFunc_Logo>("Logo");
+	HookHudMessage<&CHud::MsgFunc_Fog>("Fog");
 
 	// TFFree CommandMenu
 	HookCommand("+commandmenu", [] {
@@ -530,6 +532,8 @@ void CHud::VidInit(void)
 		HUD_FatalError("Failed to find sprite 'number_0' in the sprite list.\nYour game is corrupted.");
 
 	m_iFontHeight = m_rgrcRects[m_HUD_number_0].bottom - m_rgrcRects[m_HUD_number_0].top;
+
+	gFog.ClearFog();
 
 	for (CHudElem *i : m_HudList)
 		i->VidInit();

--- a/src/game/client/hud.h
+++ b/src/game/client/hud.h
@@ -198,6 +198,7 @@ public:
 	int MsgFunc_ViewMode(const char *pszName, int iSize, void *pbuf);
 	int MsgFunc_SetFOV(const char *pszName, int iSize, void *pbuf);
 	int MsgFunc_Concuss(const char *pszName, int iSize, void *pbuf);
+	int MsgFunc_Fog(const char *pszName, int iSize, void *pbuf);
 
 	float GetSensitivity();
 	BHopCap GetBHopCapState();

--- a/src/game/client/hud_msg.cpp
+++ b/src/game/client/hud_msg.cpp
@@ -27,6 +27,8 @@
 #include "particleman.h"
 extern IParticleMan *g_pParticleMan;
 
+#include "fog.h"
+
 #define MAX_CLIENTS 32
 
 #if !defined(_TFC)
@@ -185,5 +187,33 @@ int CHud::MsgFunc_Concuss(const char *pszName, int iSize, void *pbuf)
 		CHudStatusIcons::Get()->EnableIcon("dmg_concuss", 255, 160, 0);
 	else
 		CHudStatusIcons::Get()->DisableIcon("dmg_concuss");
+	return 1;
+}
+
+int CHud::MsgFunc_Fog(const char *pszName, int iSize, void *pbuf)
+{
+	FogParams fogParams;
+	float density;
+
+	// Reset fog parameters
+	gFog.ClearFog();
+
+	BEGIN_READ(pbuf, iSize);
+
+	fogParams.color[0] = (float)READ_BYTE(); // r
+	fogParams.color[1] = (float)READ_BYTE(); // g
+	fogParams.color[2] = (float)READ_BYTE(); // b
+
+	density = READ_FLOAT();
+
+	if (READ_OK())
+	{
+		fogParams.density = density;
+		fogParams.fogSkybox = true;
+		gFog.SetFogParameters(fogParams);
+	}
+	else
+		gFog.ClearFog();
+
 	return 1;
 }

--- a/src/game/client/tri.cpp
+++ b/src/game/client/tri.cpp
@@ -21,6 +21,7 @@
 
 #include "particleman.h"
 #include "tri.h"
+#include "fog.h"
 
 CSysModule *g_hParticleManModule = NULL;
 IParticleMan *g_pParticleMan = NULL;
@@ -100,6 +101,8 @@ void CL_DLLEXPORT HUD_DrawTransparentTriangles(void)
 #if defined(_TFC)
 	RunEventList();
 #endif
+
+	gFog.RenderFog();
 
 	if (g_pParticleMan)
 		g_pParticleMan->Update();

--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -79,6 +79,9 @@ Vector g_vViewForward;
 Vector g_vViewRight;
 Vector g_vViewUp;
 
+// Used in fog code
+int g_iWaterlevel;
+
 cvar_t *scr_ofsx;
 cvar_t *scr_ofsy;
 cvar_t *scr_ofsz;
@@ -1699,6 +1702,7 @@ void CL_DLLEXPORT V_CalcRefdef(struct ref_params_s *pparams)
 	g_vViewForward = pparams->forward;
 	g_vViewRight = pparams->right;
 	g_vViewUp = pparams->up;
+	g_iWaterlevel = pparams->waterlevel;
 
 	/*
 // Example of how to overlay the whole screen with red at 50 % alpha

--- a/src/game/server/effects.h
+++ b/src/game/server/effects.h
@@ -218,4 +218,16 @@ public:
 	Vector m_firePosition;
 };
 
+class CClientFog : public CBaseEntity
+{
+public:
+	virtual void Spawn();
+	virtual void KeyValue(KeyValueData *pkvd);
+
+public:
+	int m_iStartDist;
+	int m_iEndDist;
+	float m_fDensity;
+};
+
 #endif //EFFECTS_H

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -205,6 +205,8 @@ const char *const gCustomMessages[] = {
 	NULL
 };
 
+int gmsgFog = 0;
+
 void LinkUserMessages(void)
 {
 	// Already taken care of?
@@ -263,6 +265,8 @@ void LinkUserMessages(void)
 	{
 		REG_USER_MSG(gCustomMessages[i], 0);
 	}
+
+	gmsgFog = REG_USER_MSG("Fog", 7);
 }
 
 LINK_ENTITY_TO_CLASS(player, CBasePlayer);
@@ -4089,6 +4093,36 @@ void CBasePlayer ::UpdateClientData(void)
 				MESSAGE_BEGIN(MSG_ONE, gmsgSpectator, NULL, pev);
 				WRITE_BYTE(ENTINDEX(plr->edict())); // index number of primary entity
 				WRITE_BYTE(1);
+				MESSAGE_END();
+			}
+
+			// Send fog message
+			CBaseEntity *pEntity = UTIL_FindEntityByClassname(nullptr, "env_fog");
+			if (pEntity)
+			{
+				CClientFog *pFog = static_cast<CClientFog *>(pEntity);
+
+				int r = clamp(int(pFog->pev->rendercolor[0]), 0, 255);
+				int g = clamp(int(pFog->pev->rendercolor[1]), 0, 255);
+				int b = clamp(int(pFog->pev->rendercolor[2]), 0, 255);
+
+				union
+				{
+					float f;
+					char b[4];
+
+				} density;
+
+				density.f = pFog->m_fDensity;
+
+				MESSAGE_BEGIN(MSG_ONE, gmsgFog, nullptr, pev);
+				WRITE_BYTE(r);
+				WRITE_BYTE(g);
+				WRITE_BYTE(b);
+				WRITE_BYTE(density.b[0]);
+				WRITE_BYTE(density.b[1]);
+				WRITE_BYTE(density.b[2]);
+				WRITE_BYTE(density.b[3]);
 				MESSAGE_END();
 			}
 

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -26,6 +26,7 @@
 #include "player.h"
 #include "saverestore.h"
 #include "trains.h" // trigger_camera has train functionality
+#include "effects.h" // fog
 #include "gamerules.h"
 
 #define SF_TRIGGER_PUSH_START_OFF       2 //spawnflag that makes trigger_push spawn turned OFF
@@ -2332,4 +2333,44 @@ void CTriggerCamera::Move()
 
 	float fraction = 2 * gpGlobals->frametime;
 	pev->velocity = ((pev->movedir * pev->speed) * fraction) + (pev->velocity * (1 - fraction));
+}
+
+LINK_ENTITY_TO_CLASS(env_fog, CClientFog)
+
+void CClientFog::KeyValue(KeyValueData *pkvd)
+{
+#if 0
+	if (FStrEq(pkvd->szKeyName, "startdist"))
+	{
+		m_iStartDist = Q_atoi(pkvd->szValue);
+		pkvd->fHandled = TRUE;
+	}
+	else if (FStrEq(pkvd->szKeyName, "enddist"))
+	{
+		m_iEndDist = Q_atoi(pkvd->szValue);
+		pkvd->fHandled = TRUE;
+	}
+	else
+#endif
+	if (FStrEq(pkvd->szKeyName, "density"))
+	{
+		m_fDensity = atof(pkvd->szValue);
+
+		if (m_fDensity < 0 || m_fDensity > 0.01)
+			m_fDensity = 0;
+
+		pkvd->fHandled = TRUE;
+	}
+	else
+	{
+		CBaseEntity::KeyValue(pkvd);
+	}
+}
+
+void CClientFog::Spawn()
+{
+	pev->movetype = MOVETYPE_NOCLIP;
+	pev->solid = SOLID_NOT; // Remove model & collisions
+	pev->renderamt = 0; // The engine won't draw this model if this is set to 0 and blending is on
+	pev->rendermode = kRenderTransTexture;
 }


### PR DESCRIPTION
Adds fog support and implements "Fog" usermsg which is also the same as in CS. Can be disabled by typing `gl_fog 0` in console.

Showcase (zm_infect_click21):
![fog_hl](https://github.com/tmp64/BugfixedHL-Rebased/assets/51358194/a984ef13-ed3d-48c0-a021-afbd4082918b)
