### PR TITLE
Add _toggleweapon command

### DIFF
--- a/src/game/client/hud/ammo.cpp
+++ b/src/game/client/hud/ammo.cpp
@@ -829,6 +829,35 @@ void CHudAmmo::UserCmd_PrevWeapon(void)
 	gpActiveSel = NULL;
 }
 
+CON_COMMAND(_toggleweapon, "Change to weapon if available, otherwise fallbacks to default weapon.")
+{
+	int argc = gEngfuncs.Cmd_Argc();
+	if (argc <= 2 || argc > 3)
+	{
+		ConPrintf("usage: _toggleweapon <weapon_name> <default_weapon>\n");
+		return;
+	}
+
+	char arg1[MAX_WEAPON_NAME]; // weapon to toggle
+	char arg2[MAX_WEAPON_NAME]; // fallback weapon
+
+	sprintf(arg1, "%s", gEngfuncs.Cmd_Argv(1));
+	sprintf(arg2, "%s", gEngfuncs.Cmd_Argv(2));
+
+	for (int i = MAX_WEAPONS - 1; i > 0; i--)
+	{
+		WEAPON *p = gWR.GetWeapon(i);
+
+		if (p && (gHUD.m_iWeaponBits & (1 << p->iId)) && strcmp(p->szName, arg1) == 0)
+		{
+			ServerCmd(arg1);
+			return;
+		}
+	}
+
+	ServerCmd(arg2);
+}
+
 //-------------------------------------------------------------------------
 // Drawing code
 //-------------------------------------------------------------------------


### PR DESCRIPTION
The `_toggleweapon` command allows the player to quickly switch to a specific weapon if it is available in their inventory. If the requested weapon is not available, the command will switch to a default weapon specified.

# Usage
`_toggleweapon <weapon_name> <default_weapon>`

Where:
- `<weapon_name>`: The primary weapon the player wants to switch to, if available.
- `<default_weapon>`: The default weapon to switch to if `<weapon_name>` is not available.

# Example
`bind q "_toggleweapon weapon_shotgun weapon_crowbar"`

In this example, if you press Q, the command will first try to switch to the shotgun (`weapon_shotgun`). If the shotgun is not available in the player's inventory, it will switch to the crowbar (`weapon_crowbar`) as the default weapon.

**Benefits**:
- Provides a fallback option if the primary weapon is not available, ensuring the player always has a suitable weapon.
  -  For players who have all the weapons binded to the keyboard (which can be quite a few), the _toggleweapon command can help reduce the number of key bindings needed, making weapon switching more efficient and also having a nearby key for faster switching.