### PR TITLE
Client: fix GetThisPlayerInfo crash

### DIFF
--- a/src/game/client/hud/chat.cpp
+++ b/src/game/client/hud/chat.cpp
@@ -1279,7 +1279,7 @@ void CHudChat::ChatPrintf(int iPlayerIndex, const char *fmt, ...)
 	}
 
 	// If a player is muted for voice, also mute them for text because jerks gonna jerk.
-	if (cl_mute_all_comms.GetBool() && iPlayerIndex != 0 && iPlayerIndex != GetThisPlayerInfo()->GetIndex())
+	if (GetThisPlayerInfo() && cl_mute_all_comms.GetBool() && iPlayerIndex != 0 && iPlayerIndex != GetThisPlayerInfo()->GetIndex())
 	{
 		if (GetClientVoiceMgr() && GetClientVoiceMgr()->IsPlayerBlocked(iPlayerIndex))
 			return;

--- a/src/game/client/hud/death_notice_panel.cpp
+++ b/src/game/client/hud/death_notice_panel.cpp
@@ -82,6 +82,12 @@ void CHudDeathNoticePanel::Think()
 
 void CHudDeathNoticePanel::AddItem(int killerId, int victimId, const char *killedwith)
 {
+	if (!GetThisPlayerInfo())
+	{
+		// Not yet connected
+		return;
+	}
+
 	Entry e;
 	CPlayerInfo *killer = GetPlayerInfoSafe(killerId);
 	CPlayerInfo *victim = GetPlayerInfoSafe(victimId);

--- a/src/game/client/vgui/score_panel.cpp
+++ b/src/game/client/vgui/score_panel.cpp
@@ -209,6 +209,12 @@ void CScorePanel::UpdateOnPlayerInfo(int client)
 
 void CScorePanel::DeathMsg(int killer, int victim)
 {
+	if (!GetThisPlayerInfo())
+	{
+		// Not yet connected
+		return;
+	}
+
 	if (victim == GetThisPlayerInfo()->GetIndex())
 	{
 		// if we were the one killed, set the scoreboard to indicate killer


### PR DESCRIPTION
Decided to test newer builds of BHL and encountered that crash after connecting to some servers.
I'm not sure if the crash is fixed completely. At least, after my changes, I can't reproduce it. Tested a little bit with and without and it seems OK.