### PR TITLE
Client: HUD: Support 4+ digits for health/armor HUD elements

### DIFF
--- a/src/game/client/hud/battery.cpp
+++ b/src/game/client/hud/battery.cpp
@@ -55,7 +55,6 @@ int CHudBattery::MsgFunc_Battery(const char *pszName, int iSize, void *pbuf)
 
 	BEGIN_READ(pbuf, iSize);
 	int battery = READ_SHORT();
-	battery = clamp(battery, 0, 999);
 
 	if (battery != m_iBat)
 	{
@@ -121,5 +120,5 @@ void CHudBattery::Draw(float flTime)
 	}
 
 	x += m_rc1.GetWidth();
-	x = gHUD.DrawHudNumber(x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iBat, r, g, b);
+	x = gHUD.DrawHudNumber(x, y, m_iBat, r, g, b);
 }

--- a/src/game/client/hud/battery.cpp
+++ b/src/game/client/hud/battery.cpp
@@ -120,5 +120,9 @@ void CHudBattery::Draw(float flTime)
 	}
 
 	x += m_rc1.GetWidth();
-	x = gHUD.DrawHudNumber(x, y, m_iBat, r, g, b);
+
+	if (m_iBat < 1000)
+		x = gHUD.DrawHudNumber(x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iBat, r, g, b);
+	else
+		x = gHUD.DrawHudNumber(x, y, m_iBat, r, g, b);
 }

--- a/src/game/client/hud/health.cpp
+++ b/src/game/client/hud/health.cpp
@@ -191,7 +191,7 @@ void CHudHealth::Draw(float flTime)
 	// Apply wider range health from client_state_t structure, if available
 	cl_entity_t *player = gEngfuncs.GetLocalPlayer();
 	int health = player->curstate.health;
-	health = clamp(health, 0, 99999);
+
 	if (m_iHealth != health && health > 255)
 	{
 		m_fFade = FADE_TIME;

--- a/src/game/client/hud/health.cpp
+++ b/src/game/client/hud/health.cpp
@@ -191,7 +191,7 @@ void CHudHealth::Draw(float flTime)
 	// Apply wider range health from client_state_t structure, if available
 	cl_entity_t *player = gEngfuncs.GetLocalPlayer();
 	int health = player->curstate.health;
-	health = clamp(health, 0, 999);
+	health = clamp(health, 0, 99999);
 	if (m_iHealth != health && health > 255)
 	{
 		m_fFade = FADE_TIME;
@@ -221,7 +221,7 @@ void CHudHealth::Draw(float flTime)
 
 		x = CrossWidth + HealthWidth / 2;
 
-		x = gHUD.DrawHudNumber(x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b);
+		x = gHUD.DrawHudNumber(x, y, m_iHealth, r, g, b);
 
 		x += HealthWidth / 2;
 

--- a/src/game/client/hud/health.cpp
+++ b/src/game/client/hud/health.cpp
@@ -221,7 +221,10 @@ void CHudHealth::Draw(float flTime)
 
 		x = CrossWidth + HealthWidth / 2;
 
-		x = gHUD.DrawHudNumber(x, y, m_iHealth, r, g, b);
+		if (m_iHealth < 1000)
+			x = gHUD.DrawHudNumber(x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b);
+		else
+			x = gHUD.DrawHudNumber(x, y, m_iHealth, r, g, b);
 
 		x += HealthWidth / 2;
 


### PR DESCRIPTION
Now, if server sends big values for health/armor, these HUD elements draw whole number instead of clamped one.
![HUD](https://github.com/user-attachments/assets/67ed32eb-13bf-4fca-b637-4966b1aac6d4)
