### PR TITLE
Client: Prevent reading arbitrary network data from userinfos

### DIFF
--- a/src/common/parsemsg.cpp
+++ b/src/common/parsemsg.cpp
@@ -156,6 +156,35 @@ char *READ_STRING(void)
 	return string;
 }
 
+char *SAFE_READ_STRING(void)
+{
+	static char string[2048];
+	int l, c;
+
+	string[0] = '\0';
+	
+	l = 0;
+	while (l < (int)(sizeof(string) - 1))
+	{
+		if (giRead >= giSize)
+		{
+			giBadRead = true;
+			break;
+		}
+
+		c = READ_BYTE();
+
+		if (c == 0)
+			break;
+
+		string[l++] = (char)c;
+	}
+
+	string[l] = '\0';
+
+	return string;
+}
+
 char *READ_LINE(void)
 {
 	static char string[2048];

--- a/src/common/parsemsg.h
+++ b/src/common/parsemsg.h
@@ -30,6 +30,7 @@ int READ_WORD(void);
 int READ_LONG(void);
 float READ_FLOAT(void);
 char *READ_STRING(void);
+char *SAFE_READ_STRING(void);
 char *READ_LINE(void);
 float READ_COORD(void);
 float READ_ANGLE(void);

--- a/src/game/client/svc_messages.cpp
+++ b/src/game/client/svc_messages.cpp
@@ -121,6 +121,7 @@ void CSvcMessages::Init()
 	m_Handlers.funcs.pfnSvcStuffText = CallMember<&CSvcMessages::SvcStuffText>;
 	m_Handlers.funcs.pfnSvcSendCvarValue = CallMember<&CSvcMessages::SvcSendCvarValue>;
 	m_Handlers.funcs.pfnSvcSendCvarValue2 = CallMember<&CSvcMessages::SvcSendCvarValue2>;
+	m_Handlers.funcs.pfnSvcUpdateUserInfo = CallMember<&CSvcMessages::SvcUpdateUserInfo>;
 
 	CEnginePatches::Get().HookSvcHandlers(m_Handlers.array);
 	m_bInitialized = true;
@@ -703,4 +704,46 @@ void CSvcMessages::SvcSendCvarValue2()
 	}
 
 	CEnginePatches::Get().GetEngineSvcHandlers().pfnSvcSendCvarValue2();
+}
+
+void CSvcMessages::SvcUpdateUserInfo()
+{
+	BEGIN_READ(GetMsgBuf().GetBuf(), GetMsgBuf().GetSize(), GetMsgBuf().GetReadPos());
+
+	int slot = READ_BYTE();
+	long userid = READ_LONG();
+	char *userinfo = SAFE_READ_STRING(); // can't use READ_STRING because it can be interrupted by invalid UTF-8 symbol
+
+	// Get 16 bytes of CD key hash
+	byte cdkey[16] = {};
+	for (int i = 0; i < 16; i++)
+	{
+		cdkey[i] = READ_BYTE();
+	}
+
+	// Check if userinfo doesn't contain any bad things (https://github.com/rehlds/ReHLDS/pull/1074)
+	if (!Q_UnicodeValidate(userinfo))
+	{
+		// Seems like someone wanted to do a little trolling
+		// Now we need to prevent arbitrary network data and svc_bad kick
+		Q_UnicodeRepair(userinfo, STRINGCONVERT_REPLACE);
+		gEngfuncs.Con_DPrintf("Repaired invalid UTF-8 string in player's userinfo. Slot: %d, userid: %d\n", slot, userid);
+
+		// Rewrite buffer without invalid chars
+		byte *buffer = (byte *)GetMsgBuf().GetBuf();
+		byte *bufPtr = buffer + GetMsgBuf().GetReadPos();
+
+		*bufPtr++ = (byte)slot; // BYTE
+
+		Q_memcpy(bufPtr, &userid, sizeof(userid)); // LONG
+		bufPtr += sizeof(userid);
+
+		Q_memcpy(bufPtr, userinfo, strlen(userinfo) + 1); // STRING
+		bufPtr += Q_strlen(userinfo) + 1;
+
+		Q_memcpy(bufPtr, cdkey, sizeof(cdkey)); // 16 BYTES
+		bufPtr += sizeof(cdkey);
+	}
+
+	CEnginePatches::Get().GetEngineSvcHandlers().pfnSvcUpdateUserInfo();
 }

--- a/src/game/client/svc_messages.cpp
+++ b/src/game/client/svc_messages.cpp
@@ -738,8 +738,9 @@ void CSvcMessages::SvcUpdateUserInfo()
 		Q_memcpy(bufPtr, &userid, sizeof(userid)); // LONG
 		bufPtr += sizeof(userid);
 
-		Q_memcpy(bufPtr, userinfo, strlen(userinfo) + 1); // STRING
-		bufPtr += Q_strlen(userinfo) + 1;
+		int userInfoLength = Q_strlen(userinfo) + 1;
+		Q_memcpy(bufPtr, userinfo, userInfoLength); // STRING
+		bufPtr += userInfoLength;
 
 		Q_memcpy(bufPtr, cdkey, sizeof(cdkey)); // 16 BYTES
 		bufPtr += sizeof(cdkey);

--- a/src/game/client/svc_messages.h
+++ b/src/game/client/svc_messages.h
@@ -227,6 +227,16 @@ private:
 	 *   long: Request ID
 	 */
 	void SvcSendCvarValue2();
+
+	 /**
+	 * svc_updateuserinfo: Update client's userinfo.
+	 * Message contents:
+	 *   byte: client index
+	 *	 long: client userID
+	 *	 string: userinfo
+	 *   16 bytes: CD key hash
+	 */
+	void SvcUpdateUserInfo();
 };
 
 #endif SVC_MESSAGES_H

--- a/src/game/client/svc_messages.h
+++ b/src/game/client/svc_messages.h
@@ -232,8 +232,8 @@ private:
 	 * svc_updateuserinfo: Update client's userinfo.
 	 * Message contents:
 	 *   byte: client index
-	 *	 long: client userID
-	 *	 string: userinfo
+	 *   long: client userID
+	 *   string: userinfo
 	 *   16 bytes: CD key hash
 	 */
 	void SvcUpdateUserInfo();


### PR DESCRIPTION
More info: https://github.com/rehlds/ReHLDS/pull/1074

This commit fixes processing SVC messages from malformed userinfo.