### PR TITLE
Server: Add mp_ducktap cvar

### DIFF
--- a/src/game/server/game.cpp
+++ b/src/game/server/game.cpp
@@ -43,6 +43,7 @@ cvar_t fraglimit = { "mp_fraglimit", "0", FCVAR_SERVER };
 cvar_t timelimit = { "mp_timelimit", "0", FCVAR_SERVER };
 cvar_t friendlyfire = { "mp_friendlyfire", "0", FCVAR_SERVER };
 cvar_t bunnyhop = { "mp_bunnyhop", "1", FCVAR_SERVER };
+cvar_t ducktap = { "mp_ducktap", "1", FCVAR_SERVER };
 cvar_t falldamage = { "mp_falldamage", "0", FCVAR_SERVER };
 cvar_t weaponstay = { "mp_weaponstay", "0", FCVAR_SERVER };
 cvar_t selfgauss = { "mp_selfgauss", "1", FCVAR_SERVER };
@@ -500,6 +501,7 @@ void GameDLLInit(void)
 
 	CVAR_REGISTER(&friendlyfire);
 	CVAR_REGISTER(&bunnyhop);
+	CVAR_REGISTER(&ducktap);
 	CVAR_REGISTER(&falldamage);
 	CVAR_REGISTER(&weaponstay);
 	CVAR_REGISTER(&selfgauss);

--- a/src/game/server/game.h
+++ b/src/game/server/game.h
@@ -31,6 +31,7 @@ extern cvar_t fraglimit;
 extern cvar_t timelimit;
 extern cvar_t friendlyfire;
 extern cvar_t bunnyhop;
+extern cvar_t ducktap;
 extern cvar_t falldamage;
 extern cvar_t weaponstay;
 extern cvar_t selfgauss;

--- a/src/game/server/gamerules.cpp
+++ b/src/game/server/gamerules.cpp
@@ -43,6 +43,7 @@ ConVar mp_useslowdown("mp_useslowdown", "1", 0, "Slowdown behavior on +USE. 0 - 
 void CGameRules::Think(void)
 {
 	PM_SetBHopCapEnabled(!bunnyhop.value);
+	PM_SetDucktapCapEnabled(!ducktap.value);
 	PM_SetUseSlowDownType(mp_useslowdown.GetEnumClamped<EUseSlowDownType>());
 }
 

--- a/src/pm_shared/pm_shared.h
+++ b/src/pm_shared/pm_shared.h
@@ -72,7 +72,9 @@ void PM_ResetBHopDetection();
 void PM_ResetUseSlowDownDetection();
 #else
 int PM_GetBHopCapEnabled();
+int PM_GetDucktapCapEnabled();
 void PM_SetBHopCapEnabled(int state);
+void PM_SetDucktapCapEnabled(int state);
 #endif
 
 // Spectator Movement modes (stored in pev->iuser1, so the physics code can get at them)


### PR DESCRIPTION
An addition for `mp_bunnyhop` cvar because ducktapping technique (especially with high FPS) can replace bunnyhopping and bypass speed cap. With `mp_ducktap 0` now we can make ducktapping inefficient by decreasing speed to 0.9x. By default, the cvar is on `1` (enabled ducktap). Doesn't have prediction but it won't be so annoying with high ping. Used this on my HLZM server.

Showcase:

https://github.com/user-attachments/assets/0be1fe42-63c2-4d77-9c43-85ccf6a0744c

