### PR TITLE
Fix AG HUD texts not displaying UTF-8 characters

### DIFF
--- a/src/game/client/hud.h
+++ b/src/game/client/hud.h
@@ -165,10 +165,12 @@ public:
 	int DrawHudString(int x, int y, int iMaxX, char *szString, int r, int g, int b);
 	int DrawHudStringReverse(int xpos, int ypos, int iMinX, char *szString, int r, int g, int b);
 	int DrawHudStringColorCodes(int x, int y, int iMaxX, char *string, int _r, int _g, int _b);
+	int DrawHudStringColorCodesCentered(int x, int y, int iMaxX, char *string, int _r, int _g, int _b);
 	int DrawHudStringReverseColorCodes(int x, int y, int iMaxX, char *string, int _r, int _g, int _b);
 	int DrawHudNumberString(int xpos, int ypos, int iMinX, int iNumber, int r, int g, int b);
 	int GetNumWidth(int iNumber, int iFlags);
 	int GetHudCharWidth(int c);
+	int GetHudStringWidthColorCodes(char *string);
 	int CalculateCharWidth(int c);
 
 	//! @returns The font height for string render functions.

--- a/src/game/client/hud/ag/ag_countdown.cpp
+++ b/src/game/client/hud/ag/ag_countdown.cpp
@@ -48,7 +48,7 @@ void AgHudCountdown::Draw(float fTime)
 		{
 			// Write arena text.
 			sprintf(szText, "%s vs %s", m_szPlayer1, m_szPlayer2);
-			AgDrawHudStringCentered(ScreenWidth / 2, gHUD.m_scrinfo.iCharHeight * 7, ScreenWidth, szText, r, g, b);
+			gHUD.DrawHudStringColorCodesCentered(ScreenWidth / 2, gHUD.m_scrinfo.iCharHeight * 7, ScreenWidth, szText, r, g, b);
 		}
 		else
 		{
@@ -62,7 +62,7 @@ void AgHudCountdown::Draw(float fTime)
 		if (strlen(m_szPlayer1) != 0)
 		{
 			sprintf(szText, "Last round won by %s", m_szPlayer1);
-			AgDrawHudStringCentered(ScreenWidth / 2, gHUD.m_scrinfo.iCharHeight * 7, ScreenWidth, szText, r, g, b);
+			gHUD.DrawHudStringColorCodesCentered(ScreenWidth / 2, gHUD.m_scrinfo.iCharHeight * 7, ScreenWidth, szText, r, g, b);
 		}
 		else
 		{

--- a/src/game/client/hud/ag/ag_vote.cpp
+++ b/src/game/client/hud/ag/ag_vote.cpp
@@ -54,7 +54,7 @@ void AgHudVote::Draw(float fTime)
 	sprintf(szText, "Vote: %s %s", m_szVote, m_szValue);
 	gHUD.DrawHudString(ScreenWidth / 20, ScreenHeight / 8, 0, szText, r, g, b);
 	sprintf(szText, "Called by: %s", m_szCalled);
-	AgDrawHudString(ScreenWidth / 20, ScreenHeight / 8 + gHUD.m_scrinfo.iCharHeight, ScreenWidth, szText, r, g, b);
+	gHUD.DrawHudStringColorCodes(ScreenWidth / 20, ScreenHeight / 8 + gHUD.m_scrinfo.iCharHeight, ScreenWidth, szText, r, g, b);
 	if (VoteStatus::Called == m_iVoteStatus)
 	{
 		sprintf(szText, "For: %d", m_iFor);

--- a/src/game/client/hud_redraw.cpp
+++ b/src/game/client/hud_redraw.cpp
@@ -247,6 +247,19 @@ int CHud::DrawHudStringReverse(int xpos, int ypos, int iMinX, char *szString, in
 	return xpos - gEngfuncs.pfnDrawStringReverse(xpos, ypos, szString, r, g, b);
 }
 
+int CHud::DrawHudStringColorCodesCentered(int x, int y, int iMaxX, char *string, int _r, int _g, int _b)
+{
+	auto width = GetHudStringWidthColorCodes(string);
+	return DrawHudStringColorCodes(x - width / 2, y, iMaxX, string, _r, _g, _b);
+}
+
+int CHud::GetHudStringWidthColorCodes(char *string)
+{
+	static char buffer[1024];
+	RemoveColorCodes(string, buffer, sizeof(buffer));
+	return DrawHudStringColorCodes(0, 0, 0, buffer, 0, 0, 0);
+}
+
 int CHud::DrawHudStringColorCodes(int x, int y, int iMaxX, char *string, int _r, int _g, int _b)
 {
 	// How colorcodes work in DrawHudStringColorCodes


### PR DESCRIPTION
This PR fixes AG HUD texts for vote and match countdown not displaying UTF-8 characters correctly from players nicknames. I test this with my nickname `name "^8FurY^4.^7rtxA^4λ^0"`

Before:
<img width="521" height="275" alt="imagen" src="https://github.com/user-attachments/assets/21a2ddb1-731d-4f05-afa2-fadcf8e65b53" />
After:
<img width="454" height="268" alt="imagen" src="https://github.com/user-attachments/assets/c4693ba5-a5a3-45dd-9c62-a4a58bd73eee" />

Before:
<img width="1547" height="376" alt="imagen" src="https://github.com/user-attachments/assets/94f318a6-0bf1-4dd0-90ca-22f8db0670b6" />
After:
<img width="1562" height="379" alt="imagen" src="https://github.com/user-attachments/assets/3bdaf1e2-4e74-46cb-bbd0-f7e80246c906" />
