### PR TITLE
Server: Add mp_weapondrop_type cvar

### DIFF
--- a/src/game/server/gamerules.h
+++ b/src/game/server/gamerules.h
@@ -46,6 +46,18 @@ enum
 	GR_PLR_DROP_AMMO_NO,
 };
 
+// additional enum for flag check
+enum
+{
+	FLAG_GR_DROP_DEFAULT,
+	FLAG_GR_DROP_GUN_ALL = 1 << 0,
+	FLAG_GR_DROP_GUN_ACTIVE = 1 << 1,
+	FLAG_GR_DROP_GUN_NO = 1 << 2,
+	FLAG_GR_DROP_AMMO_ALL = 1 << 3,
+	FLAG_GR_DROP_AMMO_ACTIVE = 1 << 4,
+	FLAG_GR_DROP_AMMO_NO = 1 << 5
+};
+
 // Player relationship return codes
 enum
 {

--- a/src/game/server/multiplay_gamerules.cpp
+++ b/src/game/server/multiplay_gamerules.cpp
@@ -33,6 +33,16 @@
 
 #include <CBugfixedServer.h>
 
+ConVar mp_weapondrop_type("mp_weapondrop_type", "0", 0, "Sets drop behavior for weapons/ammo after death\n"
+    "  0  - default behavior\n"
+    "  +1 - gun: drop all\n"
+    "  +2 - gun: drop active only\n"
+    "  +4 - gun: drop none\n"
+    "  +8 - ammo: drop all\n"
+    " +16 - ammo: drop active only\n"
+    " +32 - ammo: drop none\n"
+    "  Flags can be combined (sum values).");
+
 extern DLL_GLOBAL CGameRules *g_pGameRules;
 extern DLL_GLOBAL BOOL g_fGameOver;
 extern int gmsgDeathMsg; // client dll messages
@@ -1135,6 +1145,15 @@ float CHalfLifeMultiplay::FlHEVChargerRechargeTime(void)
 //=========================================================
 int CHalfLifeMultiplay::DeadPlayerWeapons(CBasePlayer *pPlayer)
 {
+	int flags = mp_weapondrop_type.GetInt();
+
+	if (flags & FLAG_GR_DROP_GUN_ALL)
+		return GR_PLR_DROP_GUN_ALL;
+	else if (flags & FLAG_GR_DROP_GUN_ACTIVE)
+		return GR_PLR_DROP_GUN_ACTIVE;
+	else if (flags & FLAG_GR_DROP_GUN_NO)
+		return GR_PLR_DROP_GUN_NO;
+
 	return GR_PLR_DROP_GUN_ACTIVE;
 }
 
@@ -1142,6 +1161,15 @@ int CHalfLifeMultiplay::DeadPlayerWeapons(CBasePlayer *pPlayer)
 //=========================================================
 int CHalfLifeMultiplay::DeadPlayerAmmo(CBasePlayer *pPlayer)
 {
+	int flags = mp_weapondrop_type.GetInt();
+
+	if (flags & FLAG_GR_DROP_AMMO_ALL)
+		return GR_PLR_DROP_AMMO_ALL;
+	else if (flags & FLAG_GR_DROP_AMMO_ACTIVE)
+		return GR_PLR_DROP_AMMO_ACTIVE;
+	else if (flags & FLAG_GR_DROP_AMMO_NO)
+		return GR_PLR_DROP_AMMO_NO;
+
 	return GR_PLR_DROP_AMMO_ACTIVE;
 }
 


### PR DESCRIPTION
Now you can configure what weaponbox will contain after player death.

Values:

- 0  - default behavior
- +1 - gun: drop all
- +2 - gun: drop active only
- +4 - gun: drop none
- +8 - ammo: drop all
- +16 - ammo: drop active only
- +32 - ammo: drop none

 Flags can be combined (sum values). For example: `mp_weapondrop_type 9` (1+8) makes weaponbox contain all player weapons and ammo.