### PR TITLE
Fix damage indicators not being draw on custom HUD

### DIFF
--- a/gamedir/ui/scripts/HudLayoutBase.res
+++ b/gamedir/ui/scripts/HudLayoutBase.res
@@ -13,6 +13,7 @@
 	{
 		"statusbar_ypos"	"r45"
 		"ammohistory_ypos"	"r42"
+		"damage_ypos"		"r16"
 		"weapon_xpos"		"150"
 	}
 

--- a/src/game/client/hud/health.cpp
+++ b/src/game/client/hud/health.cpp
@@ -174,14 +174,18 @@ void CHudHealth::Draw(float flTime)
 	float a;
 	int HealthWidth;
 
-	if (hud_custom.GetBool())
-		return;
-
 	if ((gHUD.m_iHideHUDDisplay & HIDEHUD_HEALTH) || gEngfuncs.IsSpectateOnly())
 		return;
 
 	if (!m_hSprite)
 		m_hSprite = LoadSprite(PAIN_NAME);
+	
+	if (hud_custom.GetBool())
+	{
+		DrawDamage(flTime);
+		DrawPain(flTime);
+		return;
+	}
 
 	if (!hud_dim.GetBool())
 		a = MIN_ALPHA + ALPHA_POINTS_MAX;
@@ -468,7 +472,7 @@ void CHudHealth::UpdateTiles(float flTime, long bitsDamage)
 		{
 			// put this one at the bottom
 			pdmg->x = giDmgWidth / 8;
-			pdmg->y = ScreenHeight - giDmgHeight * 2;
+			pdmg->y = (hud_custom.GetBool() ? g_pViewport->GetDamageYPos() : ScreenHeight) -  giDmgHeight * 2;
 			pdmg->fExpire = flTime + DMG_IMAGE_LIFE;
 
 			// move everyone else up

--- a/src/game/client/vgui/client_viewport.cpp
+++ b/src/game/client/vgui/client_viewport.cpp
@@ -149,10 +149,12 @@ void CClientViewport::ReloadLayout()
 		{
 			const char* szStatusBarY = vanillaKV->GetString("statusbar_ypos", "0");
 			const char* szAmmoHistoryY = vanillaKV->GetString("ammohistory_ypos", "0");
+			const char* szDamageY = vanillaKV->GetString("damage_ypos", "0");
 			const char* szWeaponX = vanillaKV->GetString("weapon_xpos", "0");
 
 			ComputePos(szStatusBarY, m_iStatusBarYPos, 0, GetTall(), true);
 			ComputePos(szAmmoHistoryY, m_iAmmoHistoryYPos, 0, GetTall(), true);
+			ComputePos(szDamageY, m_iDamageYPos, 0, GetTall(), true);
 			ComputePos(szWeaponX, m_iWeaponXPos, 0, GetWide(),  true);
 		}
 
@@ -369,6 +371,11 @@ int CClientViewport::GetAmmoHistoryYPos()
 int CClientViewport::GetStatusBarYPos()
 {
 	return m_iStatusBarYPos;
+}
+
+int CClientViewport::GetDamageYPos()
+{
+	return m_iDamageYPos;
 }
 
 int CClientViewport::GetWeaponXPos()

--- a/src/game/client/vgui/client_viewport.h
+++ b/src/game/client/vgui/client_viewport.h
@@ -76,6 +76,7 @@ public:
 	// Allows to get custom positions to avoid overlapping with other panels
 	int GetAmmoHistoryYPos();
 	int GetStatusBarYPos();
+	int GetDamageYPos();
 	int GetWeaponXPos();
 
 	bool IsScoreBoardVisible();
@@ -153,6 +154,7 @@ private:
 	// Custom HUD positions
 	int m_iStatusBarYPos = 0;
 	int m_iAmmoHistoryYPos = 0;
+	int m_iDamageYPos = 0;
 	int m_iWeaponXPos = 0;
 
 	Color m_pTeamColors[5] = {


### PR DESCRIPTION
This fixes damage and pain indicators not being draw when the custom HUD is enabled. Also, I fixed the overlapping of the damage indicator with the custom HUD.

![200598~1](https://github.com/user-attachments/assets/128e6192-54c1-46f9-a8ff-c80fae2bf2ca)
<img width="462" height="270" alt="imagen" src="https://github.com/user-attachments/assets/f2c50639-fa11-491f-b34b-98b840d09c25" />


