### PR TITLE
Exclude specs from team count in scoreboard

### DIFF
--- a/src/game/client/vgui/score_panel.cpp
+++ b/src/game/client/vgui/score_panel.cpp
@@ -720,7 +720,9 @@ void CScorePanel::UpdateScoresAndCounts()
 		TeamData &td = m_TeamData[pi->GetTeamNumber()];
 		td.iFrags += pi->GetFrags();
 		td.iDeaths += pi->GetDeaths();
-		td.iPlayerCount++;
+		
+		if (GetPlayerTeam(pi) != TEAM_SPECTATOR)
+			td.iPlayerCount++;
 
 		iPlayerCount++;
 	}


### PR DESCRIPTION
This fixes an issue with spectators being counted in normal team players.

Before:
<img width="1030" height="886" alt="fix-before" src="https://github.com/user-attachments/assets/ce956b5d-e98b-4e10-941f-7eab7551337d" />


After:
<img width="1029" height="879" alt="fix-after" src="https://github.com/user-attachments/assets/994aa410-28a7-4e4b-9b6e-8bd536358cfb" />
