### PR TITLE
fix(client): fix team names only displaying the first letter in scoreboard on linux

### DIFF
--- a/src/game/client/vgui/score_panel.cpp
+++ b/src/game/client/vgui/score_panel.cpp
@@ -747,7 +747,7 @@ void CScorePanel::UpdateScoresAndCounts()
 			localizedName = wbuf2;
 		}
 
-		V_snwprintf(wbuf, 128, L"%s (%d/%d)", localizedName, td.iPlayerCount, iPlayerCount);
+		V_snwprintf(wbuf, 128, L"%ls (%d/%d)", localizedName, td.iPlayerCount, iPlayerCount);
 		m_pPlayerList->ModifyColumn(nTeamID, "name", wbuf);
 
 		// Team efficiency


### PR DESCRIPTION
Before
<img width="1435" height="807" alt="image" src="https://github.com/user-attachments/assets/3937553f-446e-4c09-b273-d4150a36ffe6" />
After
<img width="1435" height="807" alt="image" src="https://github.com/user-attachments/assets/9e3a5f7b-5792-4f82-a6b6-723800b0f127" />
